### PR TITLE
Augmentation cleanup, bug fixes, and VOC annotations

### DIFF
--- a/augmentation/image_augmentation.py
+++ b/augmentation/image_augmentation.py
@@ -306,7 +306,7 @@ class ImageAugmenter(object):
         bg_img, max_obj_num_per_bg, invert_mask, split_name, zero_pad_num, \
                               split_output_dir_images, split_output_dir_masks, prob_rand_trans, seed = params
 
-        np.random.seed(seed)
+        np.random.seed(seed + int(time.time()))
 
         # we restore the object path dictionary if there are no more objects to be sampled at this point
         if not self._object_collections:

--- a/augmentation/image_augmentation.py
+++ b/augmentation/image_augmentation.py
@@ -41,7 +41,7 @@ def apply_random_transformation(background_size, segmented_box, margin=0.03, max
     random_translation_y = np.random.uniform(low_norm_bound, high_norm_bound) * background_size[0]
 
     # create the transformation matrix for the generated rotation, translation and scale
-    if np.random.uniform() > prob_rand_transformation:
+    if np.random.uniform() < prob_rand_transformation:
         tf_matrix = SimilarityTransform(rotation=random_rot_angle, scale=min(background_size),
                                         translation=(random_translation_x, random_translation_y)).params
     else:

--- a/docs/image_augmentation.md
+++ b/docs/image_augmentation.md
@@ -60,11 +60,11 @@ mapping from class ID to class names described in [`tensorflow_models.md`](tenso
 
 ## Generating images and bounding box annotations from segmented masks
 
-Using object images and masks, synthetic images can be created by projecting the segmented pixels 
-onto background images, computing bounding box annotations and masks of the syntetic images. 
+Using object images and masks, synthetic images can be created by projecting the segmented pixels
+onto background images, computing bounding box annotations and masks of the syntetic images.
 
 The [`generate_detection_data.py`](../scripts/generate_detection_data.py) script handles user interactions for
-generating images, masks, and bounding box annotations from the segmented object masks.  This is done by randomly 
+generating images, masks, and bounding box annotations from the segmented object masks.  This is done by randomly
 projecting segemented object pixels onto backgrounds, then calculating the corresponding masks and bounding boxes.
 
 Usage:
@@ -74,37 +74,57 @@ $ scripts/generate_detection_data.py -h
 usage: generate_detection_data.py [-h] --data-directory DATA_DIRECTORY
                                   --background-directory BACKGROUND_DIRECTORY
                                   --class-annotations CLASS_ANNOTATIONS
+                                  --num-objects-per-class NUM_OBJECTS_PER_CLASS
+                                  --prob_rand_trans PROB_RAND_TRANS
                                   [--output-dir OUTPUT_DIR]
                                   [--output-annotation-dir OUTPUT_ANNOTATION_DIR]
+                                  [--annotation-format ANNOTATION_FORMAT]
+                                  [--invert_mask]
 
 optional arguments:
   -h, --help            show this help message and exit
-  --data-directory DATA_DIRECTORY, -d DATA_DIRECTORY
+  --data-directory, -d
                         directory where the script will look for images and
                         object masks (default: None)
-  --background-directory BACKGROUND_DIRECTORY, -bg BACKGROUND_DIRECTORY
-                        directory where the script will look for background 
+  --background-directory, -bg
+                        directory where the script will look for background
                         images (default: None)
-  --class-annotations CLASS_ANNOTATIONS, -c CLASS_ANNOTATIONS
+  --class-annotations, -c
                         file containing mappings from class ID to class name
                         (default: None)
-  --output-dir OUTPUT_DIR, -o OUTPUT_DIR
+  --num-objects-per-class -n
+                        maximum number of images per class that are used for augmentation
+                        (this means that if there are more available images from the class,
+                        not all of them will be used during augmentation)
+  --prob_rand_trans -pt
+                        probability of applying a random rotation to each object
+                        during augmentation (probability = 0 means that no rotation
+                        will be applied)
+  --output-dir, -o
                         (optional) directory to store generated images
                         (default: None)
-  --output-annotation-dir OUTPUT_ANNOTATION_DIR, -a OUTPUT_ANNOTATION_DIR
-                        (optional) directory to store the generated YAML
+  --output-annotation-dir, -a
+                        (optional) directory to store the generated
                         annotations (default: None)
-  --display-boxes, -b   (optional) whether to display the synthetic images
-                        with visualized bounding boxes (default: False)
+  --invert_mask - im
+                        whether to invert the colours of the object segmentation mask
+                        (necessary for black and white masks in case the object is black
+                        and the background is white)
+  --annotation-format -af
+                        format in which the augmented images should be annotated
+                        (allowed values 'custom' and 'voc'); in case of custom
+                        annotations, only a YAML annotation file as described below
+                        is created, while in case of VOC annotations, a VOC annotation
+                        file for each image is created as well
 ```
 
 
 
 The script will look for the objects' masks and images in the `<DATA_DIRECTORY>` and for background images in the
-`<BACKGROUND_DIRECTORY>`. It will prompt for the data split name (e.g. `go_2019_train`). This will be used as the 
-annotation file name and the prefix for the image names. If `<OUTPUT_DIR>` is not specified, the images will be 
-created under `<DATA_DIRECTORY>/synthetic_images/<split_name>`. If `<OUTPUT_ANNOTATION_DIR>` is not specified, 
-the annotations will be appended to `<DATA_DIRECTORY>/annotations/<split_name>.yml`. 
+`<BACKGROUND_DIRECTORY>`. It will prompt for the data split name (e.g. `go_2019_train`). This will be used as the
+annotation file name and the prefix for the image names. If `<OUTPUT_DIR>` is not specified, the images will be
+created under `<DATA_DIRECTORY>/synthetic_images/<split_name>`. If `<OUTPUT_ANNOTATION_DIR>` is not specified,
+the annotations will be appended to `<DATA_DIRECTORY>/annotations/<split_name>.yml`.
 
 The `<DATA_DIRECTORY>` is expected to be organized in the following manner:
 

--- a/scripts/generate_detection_data.py
+++ b/scripts/generate_detection_data.py
@@ -7,7 +7,7 @@ from dataset_interface.augmentation.image_augmentation import ImageAugmenter
 
 def generate_masks_and_annotations(data_dir, background_dir, class_annotation_file,
                                    num_objects_per_class, output_dir, output_annotation_dir,
-                                   display_boxes, invert_mask, prob_rand_trans):
+                                   invert_mask, prob_rand_trans):
     augmenter = ImageAugmenter(data_dir, background_dir, class_annotation_file, num_objects_per_class)
     if not output_dir:
         output_dir = os.path.join(data_dir, 'synthetic_images')
@@ -32,7 +32,7 @@ def generate_masks_and_annotations(data_dir, background_dir, class_annotation_fi
     if not os.path.isdir(output_dir_masks):
         print("creating directory: " + output_dir_masks)
         os.mkdir(output_dir_masks)
-        
+
     if not os.path.isdir(output_annotation_dir):
         print("creating directory: " + output_annotation_dir)
         os.mkdir(output_annotation_dir)
@@ -51,9 +51,11 @@ def generate_masks_and_annotations(data_dir, background_dir, class_annotation_fi
 
         max_obj_num_per_bg = int(prompt_for_float("enter the maximum number of objects per background"))
         # generate images
-        augmenter.generate_detection_data(split_name, output_dir_images, output_dir_masks, output_annotation_dir, 
-                                          max_obj_num_per_bg, display_boxes=display_boxes, invert_mask=invert_mask, 
-                                          num_images_per_bg=num_images_per_bg, prob_rand_trans=prob_rand_trans)
+        augmenter.generate_detection_data(split_name, output_dir_images, output_dir_masks,
+                                          output_annotation_dir, max_obj_num_per_bg,
+                                          invert_mask=invert_mask,
+                                          num_images_per_bg=num_images_per_bg,
+                                          prob_rand_trans=prob_rand_trans)
 
         if not prompt_for_yes_or_no("do you want to generate images for another dataset split?"):
             break
@@ -62,9 +64,10 @@ def generate_masks_and_annotations(data_dir, background_dir, class_annotation_fi
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description="Script to generate training images and annotations for bounding box based object detection."
-                    " This is done by randomly projecting segemented object pixels onto backgrounds, then"
-                    " calculating the corresponding bounding boxes.")
+        description="Script to generate training images and annotations for"
+                    " bounding box based object detection. This is done by"
+                    " randomly projecting segmented object pixels onto backgrounds,"
+                    " then calculating the corresponding bounding boxes.")
     parser.add_argument('--data-directory', '-d', required=True,
                         help='directory where the script will look for images and object masks')
     parser.add_argument('--background-directory', '-bg', required=True,
@@ -77,10 +80,8 @@ if __name__ == '__main__':
                         help='(optional) directory to store generated images')
     parser.add_argument('--output-annotation-dir', '-a', default=None,
                         help='(optional) directory to store the generated YAML annotations')
-    parser.add_argument('--display-boxes', '-b', action='store_true',
-                        help='(optional) whether to display the synthetic images with visualized bounding boxes')
     parser.add_argument('--invert_mask', '-im', action='store_true',
-                        help='wheter to invert the mask (Required for YCB)')
+                        help='whether to invert the mask (Required for YCB)')
     parser.add_argument('--prob_rand_trans', '-pt', required=True, type=float,
                         help='probability of a random transformation (1.0 == No transformation applied)')
     args = parser.parse_args()
@@ -88,7 +89,7 @@ if __name__ == '__main__':
     try:
         generate_masks_and_annotations(args.data_directory, args.background_directory, args.class_annotations,
                                        args.num_objects_per_class, args.output_dir,
-                                       args.output_annotation_dir, args.display_boxes, args.invert_mask, args.prob_rand_trans)
+                                       args.output_annotation_dir, args.invert_mask, args.prob_rand_trans)
         TerminalColors.formatted_print('image and annotation generation complete', TerminalColors.OKGREEN)
     except KeyboardInterrupt:
         TerminalColors.formatted_print('\nscript interrupted', TerminalColors.WARNING)

--- a/scripts/generate_detection_data.py
+++ b/scripts/generate_detection_data.py
@@ -7,7 +7,7 @@ from dataset_interface.augmentation.image_augmentation import ImageAugmenter
 
 def generate_masks_and_annotations(data_dir, background_dir, class_annotation_file,
                                    num_objects_per_class, output_dir, output_annotation_dir,
-                                   invert_mask, prob_rand_trans):
+                                   invert_mask, prob_rand_trans, annotation_format):
     augmenter = ImageAugmenter(data_dir, background_dir, class_annotation_file, num_objects_per_class)
     if not output_dir:
         output_dir = os.path.join(data_dir, 'synthetic_images')
@@ -55,7 +55,8 @@ def generate_masks_and_annotations(data_dir, background_dir, class_annotation_fi
                                           output_annotation_dir, max_obj_num_per_bg,
                                           invert_mask=invert_mask,
                                           num_images_per_bg=num_images_per_bg,
-                                          prob_rand_trans=prob_rand_trans)
+                                          prob_rand_trans=prob_rand_trans,
+                                          annotation_format=annotation_format)
 
         if not prompt_for_yes_or_no("do you want to generate images for another dataset split?"):
             break
@@ -76,20 +77,22 @@ if __name__ == '__main__':
                         help='file containing mappings from class ID to class name')
     parser.add_argument('--num-objects-per-class', '-n', required=True, type=int,
                         help='number of object per class')
+    parser.add_argument('--prob_rand_trans', '-pt', required=True, type=float,
+                        help='probability of a random transformation (1.0 == No transformation applied)')
     parser.add_argument('--output-dir', '-o', default=None,
                         help='(optional) directory to store generated images')
     parser.add_argument('--output-annotation-dir', '-a', default=None,
                         help='(optional) directory to store the generated YAML annotations')
     parser.add_argument('--invert_mask', '-im', action='store_true',
                         help='whether to invert the mask (Required for YCB)')
-    parser.add_argument('--prob_rand_trans', '-pt', required=True, type=float,
-                        help='probability of a random transformation (1.0 == No transformation applied)')
+    parser.add_argument('--annotation-format', '-af', default='custom',
+                        help='(optional) Annotation format - custom or voc (default custom)')
     args = parser.parse_args()
 
     try:
         generate_masks_and_annotations(args.data_directory, args.background_directory, args.class_annotations,
-                                       args.num_objects_per_class, args.output_dir,
-                                       args.output_annotation_dir, args.invert_mask, args.prob_rand_trans)
+                                       args.num_objects_per_class, args.output_dir, args.output_annotation_dir,
+                                       args.invert_mask, args.prob_rand_trans, args.annotation_format)
         TerminalColors.formatted_print('image and annotation generation complete', TerminalColors.OKGREEN)
     except KeyboardInterrupt:
         TerminalColors.formatted_print('\nscript interrupted', TerminalColors.WARNING)

--- a/scripts/generate_detection_data.py
+++ b/scripts/generate_detection_data.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
     parser.add_argument('--num-objects-per-class', '-n', required=True, type=int,
                         help='number of object per class')
     parser.add_argument('--prob_rand_trans', '-pt', required=True, type=float,
-                        help='probability of a random transformation (1.0 == No transformation applied)')
+                        help='probability of a random transformation (0.0 == No transformation applied)')
     parser.add_argument('--output-dir', '-o', default=None,
                         help='(optional) directory to store generated images')
     parser.add_argument('--output-annotation-dir', '-a', default=None,

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,11 @@
 from builtins import input      # for Python 2 compatibility
+
+import sys
+try:
+    sys.path.remove('/opt/ros/kinetic/lib/python2.7/dist-packages')
+except:
+    pass
+
 import argparse
 import glob
 import os


### PR DESCRIPTION
This PR makes the following changes and fixes to the augmentation utilities:
* The `display_boxes` argument is removed from `scripts/generate_detection_data.py` since it was unused by the augmentation script
* Time is used in the augmentation random seed for increased randomness; otherwise, there was a clear regularity in the generated images
* Prevented generation of empty images by resetting the image sampling pool before generating each image (but only if the pool is already empty)
* Removed the ROS Python packages from the path to prevent crashes due to OpenCV incompatibility issues
* Added support for generating VOC annotations (by passing an additional argument `-af voc` to the augmentation script)

The documentation (`docs/image_augmentation.md`) has been updated to reflect the changes.